### PR TITLE
Fix production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,4 @@ RUN apk add --no-cache bash
 COPY --from=builder /app/build/app ./build/app
 COPY --from=builder /app/scripts/wait-for-it ./scripts/wait-for-it
 COPY --from=builder /app/app/adapter/db/migration ./app/adapter/db/migration
+COPY --from=builder /app/app/adapter/template/*.gohtml ./app/adapter/template/


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Prod container cannot find `.gohtml` files

### Screenshots
<img width="987" alt="Screen Shot 2019-11-04 at 8 38 43 AM" src="https://user-images.githubusercontent.com/3537801/68139170-89d2d000-fede-11e9-8ed3-e65b8ed33f15.png">

## New Behavior
### Description
Copy all `.gohtml` in `app/adapter/template` when building prod image
