### PR TITLE
Experimental event dispatcher integration

### DIFF
--- a/app/usecase/event/dispatcher.go
+++ b/app/usecase/event/dispatcher.go
@@ -1,0 +1,79 @@
+package event
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/asaskevich/EventBus"
+)
+
+var _ Dispatcher = (*EventDispatcher)(nil)
+var _ Subscriber = (*EventDispatcher)(nil)
+
+// ErrDispatcherIsClosed tells that there is no way to perform manipulations with event dispatcher
+var ErrDispatcherIsClosed = errors.New("failed to perform the operation, the dispatcher is closed")
+
+// EventDispatcher publishes an event to all its subscribers
+type EventDispatcher struct {
+	bus      EventBus.Bus
+	lock     sync.RWMutex
+	isClosed bool
+}
+
+func (d *EventDispatcher) Dispatch(event Event) error {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	if d.isClosed {
+		return ErrDispatcherIsClosed
+	}
+
+	d.bus.Publish(event.GetName(), event)
+
+	return nil
+}
+
+func (d *EventDispatcher) Subscribe(eventName string, listener Listener) error {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	if d.isClosed {
+		return ErrDispatcherIsClosed
+	}
+
+	return d.bus.SubscribeAsync(eventName, listener.Handle, false)
+}
+
+func (d *EventDispatcher) Unsubscribe(eventName string, listener Listener) error {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	if d.isClosed {
+		return ErrDispatcherIsClosed
+	}
+
+	return d.bus.Unsubscribe(eventName, listener.Handle)
+}
+
+func (d *EventDispatcher) Close() error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.isClosed {
+		return ErrDispatcherIsClosed
+	}
+
+	d.isClosed = true
+	d.bus.WaitAsync()
+
+	return nil
+}
+
+// NewEventDispatcher creates a new instance of EventDispatcher type
+func NewEventDispatcher() *EventDispatcher {
+	return &EventDispatcher{
+		bus:      EventBus.New(),
+		lock:     sync.RWMutex{},
+		isClosed: false,
+	}
+}

--- a/app/usecase/event/dispatcher_test.go
+++ b/app/usecase/event/dispatcher_test.go
@@ -1,0 +1,167 @@
+package event
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/short-d/app/mdtest"
+)
+
+func TestEventDispatcher_Dispatch(t *testing.T) {
+	testCases := []struct {
+		name      string
+		events    []Event
+		listeners []Listener
+	}{
+		{
+			name: "one event one listener",
+			events: []Event{
+				fakeEvent("event1"),
+			},
+			listeners: []Listener{
+				&fakeListener{
+					name:          "event1",
+					expectedCalls: 1,
+				},
+			},
+		},
+		{
+			name: "one event two listener",
+			events: []Event{
+				fakeEvent("event1"),
+			},
+			listeners: []Listener{
+				&fakeListener{
+					name:          "event1",
+					expectedCalls: 1,
+				},
+				&fakeListener{
+					name:          "event1",
+					expectedCalls: 1,
+				},
+			},
+		},
+		{
+			name: "one of the listeners listens to another event",
+			events: []Event{
+				fakeEvent("event1"),
+			},
+			listeners: []Listener{
+				&fakeListener{
+					name:          "event1",
+					expectedCalls: 1,
+				},
+				&fakeListener{
+					name:          "event2",
+					expectedCalls: 0,
+				},
+			},
+		},
+		{
+			name: "two events two listeners",
+			events: []Event{
+				fakeEvent("event1"),
+				fakeEvent("event2"),
+			},
+			listeners: []Listener{
+				&fakeListener{
+					name:          "event2",
+					expectedCalls: 1,
+				},
+				&fakeListener{
+					name:          "event1",
+					expectedCalls: 1,
+				},
+			},
+		},
+		{
+			name: "multiple events calls",
+			events: []Event{
+				fakeEvent("event1"),
+				fakeEvent("event1"),
+				fakeEvent("event2"),
+				fakeEvent("event1"),
+				fakeEvent("event1"),
+				fakeEvent("event2"),
+			},
+			listeners: []Listener{
+				&fakeListener{
+					name:          "event2",
+					expectedCalls: 2,
+				},
+				&fakeListener{
+					name:          "event1",
+					expectedCalls: 4,
+				},
+				&fakeListener{
+					name:          "event1",
+					expectedCalls: 4,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			eventDispatcher := NewEventDispatcher()
+
+			err := BindListeners(eventDispatcher, testCase.listeners)
+			mdtest.Equal(t, nil, err)
+
+			for _, e := range testCase.events {
+				err = eventDispatcher.Dispatch(e)
+				mdtest.Equal(t, nil, err)
+			}
+
+			err = eventDispatcher.Close()
+			mdtest.Equal(t, nil, err)
+
+			for _, obj := range testCase.listeners {
+				listener, ok := obj.(*fakeListener)
+
+				mdtest.Equal(t, true, ok)
+				mdtest.Equal(t, listener.expectedCalls, listener.actualCalls)
+			}
+		})
+	}
+}
+
+func TestEventDispatcher_Close(t *testing.T) {
+	eventDispatcher := NewEventDispatcher()
+	listener := &fakeListener{name: "event1"}
+	_ = BindListeners(eventDispatcher, []Listener{listener})
+
+	err := eventDispatcher.Unsubscribe("event1", listener)
+	mdtest.Equal(t, nil, err)
+
+	err = eventDispatcher.Dispatch(fakeEvent("event1"))
+	mdtest.Equal(t, nil, err)
+
+	err = eventDispatcher.Close()
+	mdtest.Equal(t, nil, err)
+
+	// there was no any listener call, because we have unsubscribed the listener
+	mdtest.Equal(t, 0, listener.actualCalls)
+	mdtest.Equal(t, ErrDispatcherIsClosed, eventDispatcher.Dispatch(fakeEvent("event1")))
+}
+
+type fakeListener struct {
+	name          string
+	expectedCalls int32
+	actualCalls   int32
+}
+
+func (f *fakeListener) Handle(e Event) {
+	// atomically increase actualCalls number, because of concurrent access to this variable
+	atomic.AddInt32(&f.actualCalls, 1)
+}
+
+func (f *fakeListener) GetSubscribedEvent() string {
+	return f.name
+}
+
+type fakeEvent string
+
+func (f fakeEvent) GetName() string {
+	return string(f)
+}

--- a/app/usecase/event/interface.go
+++ b/app/usecase/event/interface.go
@@ -1,0 +1,45 @@
+package event
+
+type Dispatcher interface {
+	Emitter
+	Subscriber
+}
+
+// Emitter propagates the given event to the list of corresponding listeners
+type Emitter interface {
+	// Dispatch dispatches an event to all registered listeners
+	Dispatch(event Event) error
+}
+
+// Listener handles received events
+type Listener interface {
+	// Handle processes the received event
+	Handle(event Event)
+	// GetSubscribedEvent returns the event name this listener wants to listen to
+	GetSubscribedEvent() string
+}
+
+// Event represents a message that expects to be delivered to the corresponding listeners
+type Event interface {
+	// GetName returns the name of an event
+	GetName() string
+}
+
+// Subscriber provides the ability to subscribe a listener to an event
+type Subscriber interface {
+	// Subscribe binds the given listener to events with the provided event name
+	Subscribe(eventName string, listener Listener) error
+	// Unsubscribe unbinds the given listener from the provided event name
+	Unsubscribe(eventName string, listener Listener) error
+}
+
+// BindListeners is a helper function registers the list of listeners to the given event dispatcher
+func BindListeners(dispatcher Dispatcher, list []Listener) error {
+	for _, listener := range list {
+		if err := dispatcher.Subscribe(listener.GetSubscribedEvent(), listener); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/app/usecase/event/interface.go
+++ b/app/usecase/event/interface.go
@@ -1,5 +1,10 @@
 package event
 
+import "errors"
+
+// ErrDispatcherIsClosed represents that there is no way to perform manipulations with event dispatcher
+var ErrDispatcherIsClosed = errors.New("failed to perform the operation, the dispatcher is closed")
+
 type Dispatcher interface {
 	Emitter
 	Subscriber
@@ -34,9 +39,9 @@ type Subscriber interface {
 }
 
 // BindListeners is a helper function registers the list of listeners to the given event dispatcher
-func BindListeners(dispatcher Dispatcher, list []Listener) error {
+func BindListeners(subscriber Subscriber, list []Listener) error {
 	for _, listener := range list {
-		if err := dispatcher.Subscribe(listener.GetSubscribedEvent(), listener); err != nil {
+		if err := subscriber.Subscribe(listener.GetSubscribedEvent(), listener); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/short-d/kgs
 go 1.13
 
 require (
+	github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05
 	github.com/golang/protobuf v1.3.2
 	github.com/google/wire v0.4.0
 	github.com/short-d/app v0.0.0-20200105164223-e5615740ec60

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFD
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05 h1:Shem5lRG4gJyrrg9YMIl7dOQazyWCq0Daz4LjompZ28=
+github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
This is an experimental pull request aims to solve #51 

It does the next:
* It simplifies `UseCase` business logic
* It provides the ability to add more listeners to the specific event (in our case `PopulatedKeyEvent`)
* We can easily modify/replace any listener without touching `UseCase` entity

@byliuyang Please take a look. It is an experimental PR and is not aimed to be merged. 