### PR TITLE
KGS os signals handling

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -13,4 +13,4 @@ RUN go mod verify
 
 COPY . .
 
-CMD go run main.go start
+CMD ["go", "run", "main.go", "start"]

--- a/app/app.go
+++ b/app/app.go
@@ -55,7 +55,6 @@ func Start(
 
 	go func() {
 		<- ctx.Done()
-
 		gRpcService.Stop()
 	}()
 

--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"github.com/short-d/app/fw"
 	"github.com/short-d/kgs/dep"
 	"github.com/short-d/kgs/dep/provider"
@@ -19,6 +20,7 @@ type Config struct {
 
 // Start launches kgs service
 func Start(
+	ctx context.Context,
 	config Config,
 	dbConfig fw.DBConfig,
 	dbConnector fw.DBConnector,
@@ -50,5 +52,12 @@ func Start(
 	if err != nil {
 		panic(err)
 	}
-	gRpcService.StartAndWait(config.GRpcAPIPort)
+
+	go func() {
+		<- ctx.Done()
+
+		gRpcService.Stop()
+	}()
+
+	gRpcService.Start(config.GRpcAPIPort)
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -73,10 +73,13 @@ func Execute(rootCmd fw.Command) {
 	}
 }
 
-// listenToSystemSignals handles OS signals
 func listenToSystemSignals(cancelFn context.CancelFunc, onInterrupt func()) {
 	signalChan := make(chan os.Signal, 1)
-	// listen to Interrupt
+
+	// listen to signals in order to provide a mechanism for an orderly, graceful shutdown,
+	// but to first allow it a chance to clean up.
+	// SIGINT is the interrupt signal. The terminal sends it to the foreground process when the user presses ctrl-c
+	// SIGTERM is the termination signal. The default behaviour is to terminate the process.
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 
 	sgn := <-signalChan

--- a/dep/wire_gen.go
+++ b/dep/wire_gen.go
@@ -7,7 +7,6 @@ package dep
 
 import (
 	"database/sql"
-
 	"github.com/google/wire"
 	"github.com/short-d/app/fw"
 	"github.com/short-d/app/modern/mdcli"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -20,7 +20,7 @@ services:
       - default
     command: [
       "./scripts/wait-for-it", "-s", "-t", "0", "db:5432", "--",
-      "go", "run", "main.go", "start"
+      "sh", "-c", "go build -o build/app && ./build/app start"
     ]
   db:
     image: postgres:12.1-alpine


### PR DESCRIPTION
This resolves #57 

In order to check the behaviour, please run

`./scripts/dev`
`docker kill -s TERM kgs_dev_app_1` in a separate terminal window